### PR TITLE
NPM deployment changes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/node_modules
+demo
+coverage

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-component"
   ],
   "scripts": {
+    "prepublishOnly": "yarn run build",
     "build": "babel src --out-dir dist --ignore *.spec.js,*.snap",
     "build:watch": "babel src --out-dir dist --watch --ignore *.spec.js,*.snap",
     "lint": "standard --fix",


### PR DESCRIPTION
npmignore does not ignore dist folder, added prepublishonly hook to build dist files